### PR TITLE
Resolve issue for multiple domains usage

### DIFF
--- a/back/taiga_contrib_google_sso/services.py
+++ b/back/taiga_contrib_google_sso/services.py
@@ -85,7 +85,8 @@ def google_login_func(request, restrict_login:str=RESTRICT_LOGIN):
     token = request.DATA.get('token', None)
 
     user_info = connector.me(code)
-    if RESTRICT_LOGIN != None and user_info.email.split("@")[1] != restrict_login[0]:
+    user_domain = user_info.email.split("@")[1]
+    if RESTRICT_LOGIN != None and user_domain not in restrict_login:
         raise GoogleApiError({"error_message": ("Login with this Google account is disabled.")})
 
     user = google_register(username=user_info.username,


### PR DESCRIPTION
Title: Fix Google SSO Authentication for Multiple Domains

Overview: This pull request addresses an issue with the Google SSO integration in our application, where users from edly.io were unable to log in while users from arbisoft.com could access the application without issues. The root cause was that the authentication function only checked the first domain in the RESTRICT_LOGIN list, which restricted access for users with different domains.

Changes Made:

Updated the google_login_func to ensure that user email domains are validated against all domains listed in RESTRICT_LOGIN.